### PR TITLE
Add gRPC ecommerce example

### DIFF
--- a/example/grpc_ecommerce/README.md
+++ b/example/grpc_ecommerce/README.md
@@ -1,0 +1,16 @@
+# gRPC E-commerce Example
+
+This example demonstrates how to render a product page using Liquid templates with data fetched from three gRPC services. Each service is queried in parallel and results are cached to speed up rendering.
+
+Run the script below to render a demo page using stubbed service clients:
+
+```ruby
+product_client = ProductService::Stub.new
+category_client = CategoryService::Stub.new
+recommendation_client = RecommendationService::Stub.new
+
+page = Ecommerce::ProductPage.new(product_client, category_client, recommendation_client)
+puts page.render(1)
+```
+
+The `ProductPage` class shows how to orchestrate parallel gRPC requests and cache their responses.

--- a/example/grpc_ecommerce/product_page.rb
+++ b/example/grpc_ecommerce/product_page.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'grpc'
+require 'concurrent'
+require 'liquid'
+require 'ostruct'
+
+DemoProduct = Struct.new(:name, :description, :price, keyword_init: true)
+DemoCategory = Struct.new(:name, keyword_init: true)
+ProductRequest = Struct.new(:id)
+Empty = Struct.new(:dummy)
+RecommendationsRequest = Struct.new(:product_id)
+
+module Ecommerce
+  # Simple in-memory cache with TTL
+  class Cache
+    def initialize(max_age: 60)
+      @max_age = max_age
+      @store = {}
+    end
+
+    def fetch(key)
+      entry = @store[key]
+      if entry && (Time.now - entry[:time] < @max_age)
+        entry[:value]
+      else
+        value = yield
+        @store[key] = { value: value, time: Time.now }
+        value
+      end
+    end
+  end
+
+  # Renders a product page using data fetched from three gRPC services
+  class ProductPage
+    def initialize(product_client, category_client, recommendation_client)
+      @product_client = product_client
+      @category_client = category_client
+      @recommendation_client = recommendation_client
+      @cache = Cache.new(max_age: 300)
+    end
+
+    def render(product_id)
+      futures = Concurrent::Promises.zip(
+        fetch_product(product_id),
+        fetch_categories,
+        fetch_recommendations(product_id),
+      )
+
+      product, categories, recommendations = futures.value!
+      template.render(
+        'product' => product,
+        'categories' => categories,
+        'recommendations' => recommendations,
+      )
+    end
+
+    private
+
+    def fetch_product(id)
+      Concurrent::Promises.future do
+        @cache.fetch("product:#{id}") do
+          @product_client.fetch(ProductRequest.new(id: id))
+        end
+      end
+    end
+
+    def fetch_categories
+      Concurrent::Promises.future do
+        @cache.fetch('categories') do
+          @category_client.list(Empty.new)
+        end
+      end
+    end
+
+    def fetch_recommendations(id)
+      Concurrent::Promises.future do
+        @cache.fetch("recommendations:#{id}") do
+          @recommendation_client.list(RecommendationsRequest.new(product_id: id))
+        end
+      end
+    end
+
+    def template
+      @template ||= Liquid::Template.parse(
+        File.read(File.join(__dir__, 'templates', 'product_page.liquid')),
+      )
+    end
+  end
+end
+
+# Example service stubs used for demonstration only
+class ProductService
+  class Stub
+    def fetch(_request)
+      # Replace with real gRPC call
+      DemoProduct.new(name: "Demo Product", description: "Example", price: 10)
+    end
+  end
+end
+
+class CategoryService
+  class Stub
+    def list(_request)
+      [DemoCategory.new(name: 'Category A'), DemoCategory.new(name: 'Category B')]
+    end
+  end
+end
+
+class RecommendationService
+  class Stub
+    def list(_request)
+      [DemoProduct.new(name: 'Another Product', price: 9)]
+    end
+  end
+end

--- a/example/grpc_ecommerce/templates/product_page.liquid
+++ b/example/grpc_ecommerce/templates/product_page.liquid
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>{{ product.name }}</title>
+  </head>
+  <body>
+    <h1>{{ product.name }}</h1>
+    <p>{{ product.description }}</p>
+    <p>Price: {{ product.price }}</p>
+
+    <h2>Categories</h2>
+    <ul>
+      {% for category in categories %}
+        <li>{{ category.name }}</li>
+      {% endfor %}
+    </ul>
+
+    <h2>Recommended Products</h2>
+    <ul>
+      {% for rec in recommendations %}
+        <li>{{ rec.name }} - {{ rec.price }}</li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add gRPC example demonstrating async data fetch and caching
- include Liquid template for product page

## Testing
- `bundle install`
- `bundle exec rake`