### PR TITLE
Add improved gRPC ecommerce example

### DIFF
--- a/example/grpc_ecommerce/README.md
+++ b/example/grpc_ecommerce/README.md
@@ -1,0 +1,19 @@
+# gRPC E-commerce Example
+
+This example demonstrates how a product page can combine information from multiple gRPC services while keeping rendering responsive. Each service call is executed concurrently and cached to avoid unnecessary network requests.
+
+```ruby
+product_client = ProductService::Stub.new
+category_client = CategoryService::Stub.new
+recommendation_client = RecommendationService::Stub.new
+
+page = Ecommerce::ProductPage.new(
+  product_client,
+  category_client,
+  recommendation_client,
+)
+
+puts page.render(1)
+```
+
+The `ProductPage` class uses `Concurrent::Promises` for parallel fetches and a thread-safe cache with per-key TTLs. Replace the stub classes with real gRPC clients in a production environment.

--- a/example/grpc_ecommerce/product_page.rb
+++ b/example/grpc_ecommerce/product_page.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'grpc'
+require 'concurrent'
+require 'liquid'
+require 'ostruct'
+
+DemoProduct = Struct.new(:name, :description, :price, keyword_init: true)
+DemoCategory = Struct.new(:name, keyword_init: true)
+ProductRequest = Struct.new(:id)
+Empty = Struct.new(:dummy)
+RecommendationsRequest = Struct.new(:product_id)
+
+module Ecommerce
+  # Thread-safe in-memory cache with per-key TTL
+  class Cache
+    Entry = Struct.new(:value, :expires_at)
+
+    def initialize(default_ttl: 60)
+      @default_ttl = default_ttl
+      @store = Concurrent::Map.new
+    end
+
+    def fetch(key, ttl: @default_ttl)
+      entry = @store[key]
+      if entry && entry.expires_at > Time.now
+        entry.value
+      else
+        value = yield
+        @store[key] = Entry.new(value, Time.now + ttl)
+        value
+      end
+    end
+  end
+
+  # Renders a product page using data fetched from three gRPC services
+  class ProductPage
+    def initialize(product_client, category_client, recommendation_client, executor: Concurrent.global_io_executor)
+      @product_client = product_client
+      @category_client = category_client
+      @recommendation_client = recommendation_client
+      @executor = executor
+      @cache = Cache.new(default_ttl: 300)
+    end
+
+    def render(product_id)
+      product_f = fetch_product(product_id)
+      categories_f = fetch_categories
+      recommendations_f = fetch_recommendations(product_id)
+
+      product, categories, recommendations =
+        Concurrent::Promises.zip(product_f, categories_f, recommendations_f).value!
+
+      template.render(
+        'product' => product,
+        'categories' => categories,
+        'recommendations' => recommendations,
+      )
+    end
+
+    private
+
+    def fetch_product(id)
+      Concurrent::Promises.future_on(@executor) do
+        @cache.fetch("product:#{id}") do
+          @product_client.fetch(ProductRequest.new(id: id))
+        end
+      end
+    end
+
+    def fetch_categories
+      Concurrent::Promises.future_on(@executor) do
+        @cache.fetch('categories', ttl: 3600) do
+          @category_client.list(Empty.new)
+        end
+      end
+    end
+
+    def fetch_recommendations(id)
+      Concurrent::Promises.future_on(@executor) do
+        @cache.fetch("recommendations:#{id}", ttl: 120) do
+          @recommendation_client.list(RecommendationsRequest.new(product_id: id))
+        end
+      end
+    end
+
+    def template
+      @template ||= Liquid::Template.parse(
+        File.read(File.join(__dir__, 'templates', 'product_page.liquid')),
+      )
+    end
+  end
+end
+
+# Example service stubs used for demonstration only
+class ProductService
+  class Stub
+    def fetch(_request)
+      DemoProduct.new(name: 'Demo Product', description: 'Example', price: 10)
+    end
+  end
+end
+
+class CategoryService
+  class Stub
+    def list(_request)
+      [DemoCategory.new(name: 'Category A'), DemoCategory.new(name: 'Category B')]
+    end
+  end
+end
+
+class RecommendationService
+  class Stub
+    def list(_request)
+      [DemoProduct.new(name: 'Another Product', price: 9)]
+    end
+  end
+end

--- a/example/grpc_ecommerce/templates/product_page.liquid
+++ b/example/grpc_ecommerce/templates/product_page.liquid
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>{{ product.name }}</title>
+  </head>
+  <body>
+    <h1>{{ product.name }}</h1>
+    <p>{{ product.description }}</p>
+    <p>Price: {{ product.price }}</p>
+
+    <h2>Categories</h2>
+    <ul>
+      {% for category in categories %}
+        <li>{{ category.name }}</li>
+      {% endfor %}
+    </ul>
+
+    <h2>Recommended Products</h2>
+    <ul>
+      {% for rec in recommendations %}
+        <li>{{ rec.name }} - {{ rec.price }}</li>
+      {% endfor %}
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- refine gRPC product page example
- use thread-safe caching with TTL
- document async fetch and caching

## Testing
- `bundle exec rake`
- `bundle exec rubocop example/grpc_ecommerce/product_page.rb`
