### PR TITLE
Add gRPC dev dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ end
 
 group :development do
   gem "webrick"
+  gem "grpc"
+  gem "concurrent-ruby", require: "concurrent"
 end
 
 group :test do

--- a/History.md
+++ b/History.md
@@ -2,6 +2,8 @@
 
 ## 5.8.1 (unreleased)
 
+* Add `grpc` and `concurrent-ruby` to development dependencies [Codex]
+
 ## 5.8.1
 
 * Fix `{% doc %}` tag to be visitable [Guilherme Carreiro]


### PR DESCRIPTION
## Summary
- support grpc and concurrent-ruby gems in development
- document new dependencies

## Testing
- `bundle install` *(fails: Could not fetch specs from https://rubygems.org/)*
- `bundle exec rake` *(fails: Could not find gem 'grpc' in locally installed gems)*
